### PR TITLE
[Datacore UI] 코드관리 리스트, 메뉴관리 Tree, 좌측 공통 메뉴(AppMenu) 정렬 이슈 해결

### DIFF
--- a/ui/frontend/src/components/AppMenu.vue
+++ b/ui/frontend/src/components/AppMenu.vue
@@ -104,6 +104,14 @@ export default {
               }
               return traverse(rootNodes, item, index);
             });
+            rootNodes.sort((a, b) => a.sortOrder - b.sortOrder);
+            rootNodes.forEach((node) => {
+              if (node["children"]) {
+                node["children"] = node["children"].sort(
+                  (a, b) => a.sortOrder - b.sortOrder
+                );
+              }
+            });            
             this.menus = rootNodes;
           });
     },

--- a/ui/frontend/src/views/system/MenuManageView.vue
+++ b/ui/frontend/src/views/system/MenuManageView.vue
@@ -269,6 +269,14 @@ export default {
                 }
                 return traverse(rootNodes, item, index);
               });
+              rootNodes.sort((a, b) => a.sortOrder - b.sortOrder);
+              rootNodes.forEach(node => {
+                if(node['children']) {
+                  node['children'] = node['children'].sort(
+                    (a, b) => a.sortOrder - b.sortOrder
+                  );
+                }
+              });
               this.treeData = rootNodes;
             }
           }).catch((error) => {

--- a/ui/src/main/resources/mapper/CodeMapper.xml
+++ b/ui/src/main/resources/mapper/CodeMapper.xml
@@ -213,6 +213,7 @@
     		OR CODE_NAME LIKE '%' || #{searchValue} || '%')
     	</if>
     	</where>
+		ORDER BY CODE_GROUP_ID,SORT_ORDER
     	<include refid="common.pagingFooterSql"/>
     </select>
 </mapper>


### PR DESCRIPTION
## 연관 이슈 : #23 #24  

## 수정 사항 
### (1) [Datacore UI] 코드관리 리스트에서 code_group_id와 sort_order 기준으로 정렬이 되지 않는 문제
➜ **(참고)** _문제/원인/해결방법_ [https://github.com/IoTKETI/citydatahub_data_core_module/issues/23](https://github.com/IoTKETI/citydatahub_data_core_module/issues/23)

### (2) [Datacore UI] 메뉴관리 tree와 좌측 공통 메뉴 리스트(AppMenu)에서 sortOrder 기준으로 정렬이 되지 않는 문제 
➜ **(참고)**_문제/원인/해결방법_ [https://github.com/IoTKETI/citydatahub_data_core_module/issues/24](https://github.com/IoTKETI/citydatahub_data_core_module/issues/24)


